### PR TITLE
Change require.main.require to require for firebase-admin

### DIFF
--- a/src/auth.middleware.js
+++ b/src/auth.middleware.js
@@ -1,6 +1,6 @@
 import { log } from './util/logger';
 
-const admin = require.main.require('firebase-admin');
+const admin = require('firebase-admin');
 
 export default function firebaseAuthMiddleware(req, res, next) {
     const authorization = req.header('Authorization');


### PR DESCRIPTION
When using this package with a firebase project, in firebase functions for example, using require.main.require instead of require does not work with firebase deploy as the require.main looks for node_modules in the root folder, not the functions folder where the code is all living. 